### PR TITLE
Add key tools, switch secpk256k1 v1 for secpk256 v2, tidy up.

### DIFF
--- a/broadcaster.go
+++ b/broadcaster.go
@@ -69,7 +69,7 @@ func (h *HiveRpcNode) broadcast(ops []hiveOperation, wif *string) (string, error
 	var params []interface{}
 	params = append(params, tx)
 
-	if h.NoBroadcast == false {
+	if !h.NoBroadcast {
 		q := hrpcQuery{"condenser_api.broadcast_transaction", params}
 
 		res, err := h.rpcExec(h.address, q)

--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,12 @@ go 1.17
 require (
 	github.com/cfoxon/jsonrpc2client v0.0.0-20220410030230-4f361e74821a
 	github.com/decred/base58 v1.0.4
-	github.com/decred/dcrd/dcrec/secp256k1 v1.0.3
+	github.com/decred/dcrd/dcrec/secp256k1/v2 v2.0.0
 )
 
 require (
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.0.0 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v2 v2.0.0 // indirect
 	github.com/klauspost/compress v1.15.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.35.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cfoxon/jsonrpc2client v0.0.0-20220410030230-4f361e74821a
 	github.com/decred/base58 v1.0.4
 	github.com/decred/dcrd/dcrec/secp256k1/v2 v2.0.0
+	golang.org/x/crypto v0.0.0-20220214200702-86341886e292
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,7 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasthttp v1.35.0 h1:wwkR8mZn2NbigFsaw2Zj5r+xkmzjbrA/lyTmiSlal/Y=
 github.com/valyala/fasthttp v1.35.0/go.mod h1:t/G+3rLek+CyY9bnIE+YlMRddxVAAGjhxndDB4i4C0I=
 github.com/valyala/tcplisten v1.0.0/go.mod h1:T0xQ8SeCZGxckz9qRXTfG43PvQ/mcWh7FwZEA7Ioqkc=
+golang.org/x/crypto v0.0.0-20220214200702-86341886e292 h1:f+lwQ+GtmgoY+A2YaQxlSOnDjXcQ7ZRLWOHbC6HtRqE=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/decred/dcrd/chaincfg/chainhash v1.0.2 h1:rt5Vlq/jM3ZawwiacWjPa+smINyL
 github.com/decred/dcrd/chaincfg/chainhash v1.0.2/go.mod h1:BpbrGgrPTr3YJYRN3Bm+D9NuaFd+zGyNeIKgrhCXK60=
 github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
-github.com/decred/dcrd/dcrec/secp256k1 v1.0.3 h1:u4XpHqlscRolxPxt2YHrFBDVZYY1AK+KMV02H1r+HmU=
-github.com/decred/dcrd/dcrec/secp256k1 v1.0.3/go.mod h1:eCL8H4MYYjRvsw2TuANvEOcVMFbmi9rt/6hJUWU5wlU=
 github.com/decred/dcrd/dcrec/secp256k1/v2 v2.0.0 h1:3GIJYXQDAKpLEFriGFN8SbSffak10UXHGdIcFaMPykY=
 github.com/decred/dcrd/dcrec/secp256k1/v2 v2.0.0/go.mod h1:3s92l0paYkZoIHuj4X93Teg/HB7eGM9x/zokGw+u4mY=
 github.com/klauspost/compress v1.15.0 h1:xqfchp4whNFxn5A4XFyyYtitiWI8Hy5EW59jEwcyL6U=

--- a/hrpcclient.go
+++ b/hrpcclient.go
@@ -3,9 +3,10 @@ package hivego
 import (
 	"encoding/json"
 	"errors"
-	"github.com/cfoxon/jsonrpc2client"
 	"log"
 	"strconv"
+
+	"github.com/cfoxon/jsonrpc2client"
 )
 
 type HiveRpcNode struct {
@@ -104,9 +105,7 @@ func (h *HiveRpcNode) rpcExecBatchFast(endpoint string, queries []hrpcQuery) ([]
 	}
 
 	var batchResult [][]byte
-	for _, resp := range resps {
-		batchResult = append(batchResult, resp)
-	}
+	batchResult = append(batchResult, resps...)
 
 	return batchResult, nil
 }

--- a/keys.go
+++ b/keys.go
@@ -1,0 +1,109 @@
+package hivego
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/decred/base58"
+	"github.com/decred/dcrd/dcrec/secp256k1/v2"
+
+	//lint:ignore SA1019 ripemd160 is used for checksums of public keys and is required for compatibility with Hive
+	"golang.org/x/crypto/ripemd160"
+)
+
+var PublicKeyPrefix = "STM"
+
+type KeyPair struct {
+	PrivateKey *secp256k1.PrivateKey
+	PublicKey  *secp256k1.PublicKey
+}
+
+// Gets a KeyPair from a given WIF String
+func KeyPairFromWif(wif string) (*KeyPair, error) {
+	privKey, _, err := GphBase58CheckDecode(wif)
+
+	if err != nil {
+		return nil, err
+	}
+
+	prvKey, pubKey := secp256k1.PrivKeyFromBytes(privKey)
+
+	return &KeyPair{prvKey, pubKey}, nil
+}
+
+// Decodes a base58 Hive public key to secp256k1 public key
+func DecodePublicKey(pubKey string) (*secp256k1.PublicKey, error) {
+	// check prefix matches
+	if pubKey[:len(PublicKeyPrefix)] != PublicKeyPrefix {
+		return nil, errors.New("invalid prefix")
+	}
+
+	// remove prefix
+	pubKey = pubKey[len(PublicKeyPrefix):]
+
+	// decode base58
+	decoded := base58.Decode(pubKey)
+
+	// get checksum
+	checksum := decoded[len(decoded)-4:]
+
+	// get public key
+	pubKeyBytes := decoded[:len(decoded)-4]
+
+	// get ripemd160 hash (checksum)
+	hasher := ripemd160.New()
+	_, err := hasher.Write(pubKeyBytes)
+	newChecksum := hasher.Sum(nil)[:4]
+
+	if err != nil {
+		return nil, err
+	}
+
+	// check if checksums match
+	if !bytes.Equal(checksum, newChecksum) {
+		return nil, errors.New("checksums do not match")
+	}
+
+	parsedKey, err := secp256k1.ParsePubKey(pubKeyBytes)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return parsedKey, nil
+}
+
+func (kp *KeyPair) GetPublicKeyString() *string {
+	return GetPublicKeyString(kp.PublicKey)
+}
+
+func GetPublicKeyString(pubKey *secp256k1.PublicKey) *string {
+	if pubKey == nil {
+		return nil
+	}
+
+	pubKeyBytes := pubKey.SerializeCompressed()
+
+	// get ripemd160 hash
+	hasher := ripemd160.New()
+	_, err := hasher.Write(pubKeyBytes)
+
+	if err != nil {
+		return nil
+	}
+
+	// get checksum
+	checksum := hasher.Sum(nil)[:4]
+
+	// append checksum to public key
+
+	pubKeyBytes = append(pubKeyBytes, checksum...)
+
+	// encode to base58
+	encoded := base58.Encode(pubKeyBytes)
+
+	// add prefix
+	encoded = PublicKeyPrefix + encoded
+
+	return &encoded
+}

--- a/keys_test.go
+++ b/keys_test.go
@@ -1,0 +1,63 @@
+package hivego_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cfoxon/hivego"
+	"github.com/decred/dcrd/dcrec/secp256k1/v2"
+)
+
+func TestKeyPairFromWif(t *testing.T) {
+	keyPair, err := hivego.KeyPairFromWif("5JUvJcF6rQvFbZLtDFagreKCYWWcHpHApy7sbRHZ6PeZYNftLh6")
+
+	if err != nil {
+		t.Error("Failed to decode valid private key")
+	}
+
+	var expectedPubKey = []byte{3, 106, 48, 22, 243, 45, 96, 255, 51, 197, 8, 179, 85, 147, 131, 32, 165, 214, 76, 64, 90, 168, 63, 67, 124, 7, 139, 26, 114, 145, 144, 94, 153}
+	var actualPubKey = keyPair.PublicKey.Serialize()
+
+	if !bytes.Equal(expectedPubKey, actualPubKey) {
+		t.Errorf("Public Key %v does not match expected key %v", actualPubKey, expectedPubKey)
+	}
+
+	var expectedPrivKey = []byte{87, 184, 167, 38, 175, 19, 89, 57, 56, 199, 44, 31, 237, 202, 159, 200, 87, 40, 158, 247, 154, 118, 181, 226, 213, 12, 41, 131, 159, 122, 80, 230}
+	var actualPrivKey = keyPair.PrivateKey.Serialize()
+
+	if !bytes.Equal(expectedPrivKey, actualPrivKey) {
+		t.Errorf("Private Key %v does not match expected key %v", actualPrivKey, expectedPrivKey)
+	}
+}
+
+func TestDecodePublicKey(t *testing.T) {
+	pubKey, err := hivego.DecodePublicKey("STM7dzxQo2aaav9weydSVAwqewcUz2GbUwyWrAVqkdiKsD6V1uX8B")
+
+	if err != nil {
+		t.Errorf("Error Decoding valid public key")
+	}
+
+	var expectedPubKey = []byte{3, 106, 48, 22, 243, 45, 96, 255, 51, 197, 8, 179, 85, 147, 131, 32, 165, 214, 76, 64, 90, 168, 63, 67, 124, 7, 139, 26, 114, 145, 144, 94, 153}
+	var actualPubKey = pubKey.Serialize()
+
+	if !bytes.Equal(expectedPubKey, actualPubKey) {
+		t.Errorf("Public Key %v does not match expected key %v", actualPubKey, expectedPubKey)
+	}
+}
+
+func TestGetPublicKeyString(t *testing.T) {
+	var pubKeyData = []byte{3, 106, 48, 22, 243, 45, 96, 255, 51, 197, 8, 179, 85, 147, 131, 32, 165, 214, 76, 64, 90, 168, 63, 67, 124, 7, 139, 26, 114, 145, 144, 94, 153}
+	const pubKeyStringExpected = "STM7dzxQo2aaav9weydSVAwqewcUz2GbUwyWrAVqkdiKsD6V1uX8B"
+
+	pubKey, err := secp256k1.ParsePubKey(pubKeyData)
+
+	if err != nil {
+		t.Error("Couldn't parse public key to run test")
+	}
+
+	pubKeyString := hivego.GetPublicKeyString(pubKey)
+
+	if *pubKeyString != pubKeyStringExpected {
+		t.Errorf("Public Key string %s does not match expected string %s", *pubKeyString, pubKeyStringExpected)
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ At this time, there are only a few functions from the client. More will be added
 ### Example usage:
 create a client:
 ```
-hrpc := hivego.NewHiveRpc("https://api.myHiveBlockcchainNode.com")
+hrpc := hivego.NewHiveRpc("https://api.myHiveBlockchainNode.com")
 ```
 
 submit a custom json tx:

--- a/signer.go
+++ b/signer.go
@@ -7,9 +7,10 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"github.com/decred/base58"
-	"github.com/decred/dcrd/dcrec/secp256k1"
 	"time"
+
+	"github.com/decred/base58"
+	"github.com/decred/dcrd/dcrec/secp256k1/v2"
 )
 
 type signingDataFromChain struct {

--- a/signer.go
+++ b/signer.go
@@ -70,13 +70,13 @@ func hashTx(tx []byte) []byte {
 }
 
 func SignDigest(digest []byte, wif *string) ([]byte, error) {
-	pk, _, err := GphBase58CheckDecode(*wif)
+	keyPair, err := KeyPairFromWif(*wif)
+
 	if err != nil {
 		return nil, err
 	}
-	privKey, _ := secp256k1.PrivKeyFromBytes(pk)
 
-	return secp256k1.SignCompact(privKey, digest, true)
+	return secp256k1.SignCompact(keyPair.PrivateKey, digest, true)
 }
 
 func GphBase58CheckDecode(input string) ([]byte, [1]byte, error) {


### PR DESCRIPTION
Secpk256k1 v1 relies on v2 for functions and so we can remove 1 dependency by using v2 directly (it has the same api)

All tests run and passing.